### PR TITLE
String literals

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -96,6 +96,10 @@ func readString(l *lex.State) lex.StateFn {
 		l.Errorf(l.TokenPos(), "String should start with \", not with '%v'", string(r))
 	}
 	for r := l.Next(); r != '"'; r = l.Next() {
+		if r == '\\' && l.Peek() == '"' {
+			// Escaped double quote
+			l.Next()
+		}
 		if r == lex.EOF {
 			l.Errorf(l.TokenPos(), "Couldn't find end of string, reached EOF", string(r))
 		}

--- a/pkg/lexer/tok/tokens.go
+++ b/pkg/lexer/tok/tokens.go
@@ -19,6 +19,8 @@ const (
 	BOOL
 	// Native rune type in golang
 	LETTER
+	// String
+	STRING
 	NULL
 )
 

--- a/tests/lexer_test.go
+++ b/tests/lexer_test.go
@@ -44,13 +44,15 @@ func TestElements(t *testing.T) {
 
 		{input: "\"\"", tokens: []lex.Token{tok.STRING}},
 		{input: "\"alola\"", tokens: []lex.Token{tok.STRING}},
+		{input: "\"al\\\"ola\"", tokens: []lex.Token{tok.STRING}},
 
 		{input: "()", tokens: []lex.Token{tok.LBRACE, tok.RBRACE}},
 		{input: "(     )", tokens: []lex.Token{tok.LBRACE, tok.RBRACE}},
 		{input: "(+ 1 2)", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.INT, tok.INT, tok.RBRACE}},
 		{input: "(+12)", tokens: []lex.Token{tok.LBRACE, tok.INT, tok.RBRACE}},
 		{input: "(setq x 2)", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.IDENT, tok.INT, tok.RBRACE}},
-		{input: "(append \"abo\" \"ba\")", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.STRING, tok.STRING, tok.RBRACE}},
+		{input: "(repeat \":kae:\" 1000)", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.STRING, tok.INT, tok.RBRACE}},
+		{input: "(append \"a\\\"bo\" \"ba\\\"\")", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.STRING, tok.STRING, tok.RBRACE}},
 	} {
 		l := lexer.New(lex.NewFile("tmp", strings.NewReader(tc.input)))
 		tokens := ReadTokens(l)

--- a/tests/lexer_test.go
+++ b/tests/lexer_test.go
@@ -42,11 +42,15 @@ func TestElements(t *testing.T) {
 
 		{input: "a4", tokens: []lex.Token{tok.IDENT}},
 
+		{input: "\"\"", tokens: []lex.Token{tok.STRING}},
+		{input: "\"alola\"", tokens: []lex.Token{tok.STRING}},
+
 		{input: "()", tokens: []lex.Token{tok.LBRACE, tok.RBRACE}},
 		{input: "(     )", tokens: []lex.Token{tok.LBRACE, tok.RBRACE}},
 		{input: "(+ 1 2)", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.INT, tok.INT, tok.RBRACE}},
 		{input: "(+12)", tokens: []lex.Token{tok.LBRACE, tok.INT, tok.RBRACE}},
 		{input: "(setq x 2)", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.IDENT, tok.INT, tok.RBRACE}},
+		{input: "(append \"abo\" \"ba\")", tokens: []lex.Token{tok.LBRACE, tok.IDENT, tok.STRING, tok.STRING, tok.RBRACE}},
 	} {
 		l := lexer.New(lex.NewFile("tmp", strings.NewReader(tc.input)))
 		tokens := ReadTokens(l)


### PR DESCRIPTION
Tokenize string literals. Double quotes escaped with `\` are supported.
